### PR TITLE
Added SetRichPresence and ClearRichPresence

### DIFF
--- a/api.json
+++ b/api.json
@@ -544,6 +544,44 @@
                             "returns": [],
                             "summary": "Activates game overlay web browser directly to the specified URL.",
                             "usage": null
+                        },
+                        {
+                            "description": "",
+                            "has_params": true,
+                            "has_returns": true,
+                            "name": "friends_set_rich_presence",
+                            "params": [
+                                {
+                                    "description": "",
+                                    "name": "key",
+                                    "type": "string"
+                                },
+                                {
+                                    "description": "",
+                                    "name": "value",
+                                    "type": "string"
+                                }
+                            ],
+                            "params_string": "key,value",
+                            "returns": [
+                                {
+                                    "description": "True if the rich presence was set successfully, otherwise False.",
+                                    "name": "success",
+                                    "type": "bool"
+                                }
+                            ],
+                            "summary": "Sets a Rich Presence key/value for the current user.",
+                            "usage": null
+                        },
+                        {
+                            "description": "",
+                            "has_params": false,
+                            "has_returns": false,
+                            "name": "friends_clear_rich_presence",
+                            "params": [],
+                            "returns": [],
+                            "summary": "Clears all of the current user's Rich Presence key/values.",
+                            "usage": null
                         }
                     ],
                     "file_description": "Steam Overlay.",

--- a/api.md
+++ b/api.md
@@ -264,6 +264,23 @@ PARAMS
 * `mode` [`number`] - EActivateGameOverlayToWebPageMode
 
 
+### friends_set_rich_presence(key,value)
+Sets a Rich Presence key/value for the current user. 
+
+
+PARAMS
+* `key` [`string`] - 
+* `value` [`string`] - 
+
+RETURNS
+* `success` [`bool`] - True if the rich presence was set successfully, otherwise False.
+
+
+### friends_clear_rich_presence()
+Clears all of the current user&#x27;s Rich Presence key/values. 
+
+
+
 ---
 
 ## steam_listener

--- a/examples/friends/friends.gui
+++ b/examples/friends/friends.gui
@@ -7,211 +7,47 @@ textures {
   name: "rpg"
   texture: "/gooey/themes/rpg/images/rpg.atlas"
 }
-background_color {
-  x: 0.0
-  y: 0.0
-  z: 0.0
-  w: 0.0
-}
 nodes {
   position {
     x: 71.0
     y: 683.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEMPLATE
   id: "back"
-  layer: ""
   inherit_alpha: true
-  alpha: 1.0
   template: "/gooey/themes/rpg/components/button.gui"
-  template_node_child: false
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
   size {
     x: 120.0
     y: 49.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "rpg/buttonSquare_blue"
   id: "back/bg"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
   parent: "back"
-  layer: "below"
-  inherit_alpha: true
-  slice9 {
-    x: 8.0
-    y: 20.0
-    z: 8.0
-    w: 20.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
   overridden_fields: 4
   template_node_child: true
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
   text: "< BACK"
-  font: "rpg"
   id: "back/label"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  outline {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
   parent: "back/bg"
-  layer: "text"
-  inherit_alpha: true
-  alpha: 1.0
-  outline_alpha: 0.0
-  shadow_alpha: 1.0
   overridden_fields: 8
   template_node_child: true
-  text_leading: 1.0
-  text_tracking: 0.0
 }
 nodes {
   position {
     x: 161.0
     y: 448.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   size {
     x: 300.0
     y: 400.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
   texture: "rpg/panel_blue"
   id: "infopanel"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
-  layer: ""
   inherit_alpha: true
   slice9 {
     x: 24.0
@@ -219,171 +55,60 @@ nodes {
     z: 24.0
     w: 24.0
   }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
-  template_node_child: false
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
   position {
     x: -136.0
     y: 188.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   size {
     x: 200.0
     y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
   text: "<text>"
   font: "rpg"
   id: "info"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
   pivot: PIVOT_NW
   outline {
     x: 1.0
     y: 1.0
     z: 1.0
-    w: 1.0
   }
   shadow {
     x: 1.0
     y: 1.0
     z: 1.0
-    w: 1.0
   }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
   parent: "infopanel"
-  layer: ""
   inherit_alpha: true
-  alpha: 1.0
-  outline_alpha: 1.0
-  shadow_alpha: 1.0
-  template_node_child: false
-  text_leading: 1.0
-  text_tracking: 0.0
 }
 nodes {
   position {
     x: 108.0
     y: 158.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   size {
     x: 32.0
     y: 32.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: ""
   id: "avatar"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
   parent: "infopanel"
-  layer: ""
   inherit_alpha: true
-  slice9 {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 0.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
-  template_node_child: false
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
   position {
     x: 478.0
     y: 448.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   size {
     x: 300.0
     y: 400.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
   texture: "rpg/panel_blue"
   id: "friendspanel"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
-  layer: ""
   inherit_alpha: true
   slice9 {
     x: 24.0
@@ -391,75 +116,101 @@ nodes {
     z: 24.0
     w: 24.0
   }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
-  template_node_child: false
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
   position {
     x: -136.0
     y: 188.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   size {
     x: 200.0
     y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
   text: "<text>"
   font: "rpg"
   id: "friends"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
   pivot: PIVOT_NW
   outline {
     x: 1.0
     y: 1.0
     z: 1.0
-    w: 1.0
   }
   shadow {
     x: 1.0
     y: 1.0
     z: 1.0
-    w: 1.0
   }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
   parent: "friendspanel"
-  layer: ""
   inherit_alpha: true
-  alpha: 1.0
-  outline_alpha: 1.0
-  shadow_alpha: 1.0
-  template_node_child: false
-  text_leading: 1.0
-  text_tracking: 0.0
+}
+nodes {
+  position {
+    x: 797.0
+    y: 448.0
+  }
+  size {
+    x: 300.0
+    y: 400.0
+  }
+  type: TYPE_BOX
+  texture: "rpg/panel_blue"
+  id: "rich_presence_panel"
+  inherit_alpha: true
+  slice9 {
+    x: 24.0
+    y: 24.0
+    z: 24.0
+    w: 24.0
+  }
+}
+nodes {
+  position {
+    y: 149.0
+  }
+  type: TYPE_TEMPLATE
+  id: "set_rich_presence"
+  parent: "rich_presence_panel"
+  inherit_alpha: true
+  template: "/gooey/themes/rpg/components/button.gui"
+}
+nodes {
+  type: TYPE_BOX
+  id: "set_rich_presence/bg"
+  parent: "set_rich_presence"
+  template_node_child: true
+}
+nodes {
+  type: TYPE_TEXT
+  text: "Set Rich Presence"
+  id: "set_rich_presence/label"
+  parent: "set_rich_presence/bg"
+  overridden_fields: 8
+  template_node_child: true
+}
+nodes {
+  position {
+    y: 90.0
+  }
+  type: TYPE_TEMPLATE
+  id: "clear_rich_presence"
+  parent: "rich_presence_panel"
+  inherit_alpha: true
+  template: "/gooey/themes/rpg/components/button.gui"
+}
+nodes {
+  type: TYPE_BOX
+  id: "clear_rich_presence/bg"
+  parent: "clear_rich_presence"
+  template_node_child: true
+}
+nodes {
+  type: TYPE_TEXT
+  text: "Clear Rich Presence"
+  id: "clear_rich_presence/label"
+  parent: "clear_rich_presence/bg"
+  overridden_fields: 8
+  template_node_child: true
 }
 layers {
   name: "below"
@@ -469,4 +220,3 @@ layers {
 }
 material: "/builtins/materials/gui.material"
 adjust_reference: ADJUST_REFERENCE_PARENT
-max_nodes: 512

--- a/examples/friends/friends.gui_script
+++ b/examples/friends/friends.gui_script
@@ -73,4 +73,16 @@ function on_input(self, action_id, action)
 	rpg.button("back", action_id, action, function()
 		monarch.back()
 	end)
+	rpg.button("set_rich_presence", action_id, action, function()
+		local ok = steam.friends_set_rich_presence("steam_display", "#Status_AtMainMenu")
+		if ok then
+			print("Rich Presence successfully set")
+		else
+			print("Unable to set Rich Presence")
+		end
+	end)
+	rpg.button("clear_rich_presence", action_id, action, function()
+		steam.friends_clear_rich_presence()
+		print("Rich Presence cleared")
+	end)
 end

--- a/steam/api/steam.script_api
+++ b/steam/api/steam.script_api
@@ -220,6 +220,25 @@
       type: number
       desc: EActivateGameOverlayToWebPageMode
 
+  - name: friends_set_rich_presence
+    type: function
+    desc: Sets a Rich Presence key/value for the current user. 
+    parameters:
+    - name: key
+      type: string
+
+    - name: value
+      type: string
+
+    returns:
+    - name: success
+      type: bool
+      desc: True if the rich presence was set successfully, otherwise False.
+
+  - name: friends_clear_rich_presence
+    type: function
+    desc: Clears all of the current user&#x27;s Rich Presence key/values. 
+
   - name: set_listener
     type: function
     desc: Set a listener. 

--- a/steam/src/steam.cpp
+++ b/steam/src/steam.cpp
@@ -223,6 +223,8 @@ static const luaL_reg Module_methods[] = {
 	{ "friends_get_small_friend_avatar", SteamFriends_GetSmallFriendAvatar },
 	{ "friends_activate_game_overlay_to_store", SteamFriends_ActivateGameOverlayToStore },
 	{ "friends_activate_game_overlay_to_web_page", SteamFriends_ActivateGameOverlayToWebPage },
+	{ "friends_set_rich_presence", SteamFriends_SetRichPresence },
+	{ "friends_clear_rich_presence", SteamFriends_ClearRichPresence },
 
 	// USER
 	{ "user_get_steam_id", SteamUser_GetSteamId },

--- a/steam/src/steam_friends.cpp
+++ b/steam/src/steam_friends.cpp
@@ -219,4 +219,34 @@ int SteamFriends_ActivateGameOverlayToWebPage(lua_State* L)
 }
 
 
+/** Sets a Rich Presence key/value for the current user.
+ * @name friends_set_rich_presence
+ * @string key
+ * @string value
+ * @treturn bool success True if the rich presence was set successfully, otherwise False.
+ */
+ int SteamFriends_SetRichPresence(lua_State* L)
+{
+	if (!g_SteamFriends) return 0;
+	DM_LUA_STACK_CHECK(L, 1);
+	const char *pchKey = luaL_checkstring(L, 1);
+	const char *pchValue = luaL_checkstring(L, 2);
+	bool success = g_SteamFriends->SetRichPresence(pchKey, pchValue);
+	lua_pushboolean(L, success);
+	return 1;
+}
+
+
+/** Clears all of the current user's Rich Presence key/values.
+ * @name friends_clear_rich_presence
+ */
+ int SteamFriends_ClearRichPresence(lua_State* L)
+{
+	if (!g_SteamFriends) return 0;
+	DM_LUA_STACK_CHECK(L, 0);
+	g_SteamFriends->ClearRichPresence();
+	return 1;
+}
+
+
 #endif

--- a/steam/src/steam_friends.h
+++ b/steam/src/steam_friends.h
@@ -17,6 +17,8 @@ int SteamFriends_GetFriendRelationship(lua_State* L);
 int SteamFriends_GetSmallFriendAvatar(lua_State* L);
 int SteamFriends_ActivateGameOverlayToStore(lua_State* L);
 int SteamFriends_ActivateGameOverlayToWebPage(lua_State* L);
+int SteamFriends_SetRichPresence(lua_State* L);
+int SteamFriends_ClearRichPresence(lua_State* L);
 
 #endif
 


### PR DESCRIPTION
I did some modifications on my fork to support two functions related to the [Enhanced Rich Presence](https://partner.steamgames.com/doc/features/enhancedrichpresence). and I think it could be nice to add them to the lib!

Adds:
- SteamFriends [SetRichPresence](https://partner.steamgames.com/doc/api/ISteamFriends#SetRichPresence)
- SteamFriends [ClearRichPresence](https://partner.steamgames.com/doc/api/ISteamFriends#ClearRichPresence)

I have added a couple buttons on the friends UI so that it can be tested. However, as the demo app here doesn't have any localization set on SteamWorks, it is necessary to use https://steamcommunity.com/dev/testrichpresence in order to see the results (this is suggested in the [doc](https://partner.steamgames.com/doc/features/enhancedrichpresence#4)), as it won't show on the Steam client without localization configured.

It shows like this on the tester page:
![rich_presence_tester](https://github.com/user-attachments/assets/b2044a03-584a-44c8-9845-c047160e266e)

Also, I have been able to test my branch on my own app as well, here is the result:
![presence_steam](https://github.com/user-attachments/assets/8498b38f-82d0-4877-ab9c-8cc0d43d91e2)
![rich_presence_tester_tug](https://github.com/user-attachments/assets/5621ed3f-7791-4f21-88ff-8076d7a07881)

Just a little note about the usage, if a developer is using placeholders in the localization tokens such as:
```
"lang"
{
	"english"
	{
		"tokens"
		{
			"#Status_Playing"	"Starship Lvl%level%"
		}
	}
}
```
Then it is necessary to call the function multiple times with the required keys, e.g.:
```lua
steam.friends_set_rich_presence("steam_display", "#Status_Playing")
steam.friends_set_rich_presence("level", "5")
```