### PR TITLE
Fix build for Clang <17

### DIFF
--- a/steam/ext.manifest
+++ b/steam/ext.manifest
@@ -1,6 +1,9 @@
 name: "steam"
 
 platforms:
+    common:
+        context:
+            flags: ["-std=c++11"]
     x86_64-linux:
         context:
             dynamicLibs: ['steam_api', 'sdkencryptedappticket']


### PR DESCRIPTION
Struct like these 
```
struct RemotePlayInput_t
{
	RemotePlaySessionID_t m_unSessionID;
	ERemotePlayInputType m_eType;

	union
	{
		// Mouse motion event data, valid when m_eType is k_ERemotePlayInputMouseMotion
		RemotePlayInputMouseMotion_t m_MouseMotion;

		// Mouse button event data, valid when m_eType is k_ERemotePlayInputMouseButtonDown or k_ERemotePlayInputMouseButtonUp
		ERemotePlayMouseButton m_eMouseButton;

		// Mouse wheel event data, valid when m_eType is k_ERemotePlayInputMouseWheel
		RemotePlayInputMouseWheel_t m_MouseWheel;

		// Key event data, valid when m_eType is k_ERemotePlayInputKeyDown or k_ERemotePlayInputKeyUp
		RemotePlayInputKey_t m_Key;

		// Unused space for future use
		char padding[ 64 - ( sizeof( m_unSessionID ) + sizeof( m_eType ) ) ];
	};
};
```
requires c++11 standard because of support non-static data member feature.
As I understand by default Clang 17 accepts such constructions, but Clang <17 not. It can be a problem for macos build with Clang 16.