### PR TITLE
Implement the ISteamUser::GetAuthTicketForWebApi function

### DIFF
--- a/examples/user/user.gui
+++ b/examples/user/user.gui
@@ -102,6 +102,30 @@ nodes {
   overridden_fields: 8
   template_node_child: true
 }
+nodes {
+  position {
+    x: 443.0
+    y: 559.0
+  }
+  type: TYPE_TEMPLATE
+  id: "get_auth_for_webapi"
+  inherit_alpha: true
+  template: "/gooey-rpg/components/button.gui"
+}
+nodes {
+  type: TYPE_BOX
+  id: "get_auth_for_webapi/bg"
+  parent: "get_auth_for_webapi"
+  template_node_child: true
+}
+nodes {
+  type: TYPE_TEXT
+  text: "GET AUTH FOR WEBAPI"
+  id: "get_auth_for_webapi/label"
+  parent: "get_auth_for_webapi/bg"
+  overridden_fields: 8
+  template_node_child: true
+}
 layers {
   name: "below"
 }

--- a/examples/user/user.gui_script
+++ b/examples/user/user.gui_script
@@ -39,6 +39,18 @@ function init(self)
 	))
 
 	steam.set_listener(function(self, e, t)
+		if e == "GetTicketForWebApiResponse_t" then
+			if t.m_hAuthTicket ~= self.expected_ticket_handle then
+				print("unexpected ticket handle", t.m_hAuthTicket, self.expected_ticket_handle)
+				return
+			end
+			local ticket = t.m_rgubTicket
+			local hex = ticket:gsub(".", function(char)
+				return string.format("%02X", char:byte())
+			end)
+			print("ticket", hex)
+			return
+		end
 		print("listener event", e)
 		pprint(t)
 	end)
@@ -64,6 +76,16 @@ function on_input(self, action_id, action)
 				return string.format("%02X", char:byte())
 			end)
 			print("ticket", hex)
+		else
+			print("error", err)
+		end
+	end)
+
+	rpg.button("get_auth_for_webapi", action_id, action, function()
+		local hAuthTicket, err = steam.user_get_auth_ticket_for_web_api("your-backend.example.com")
+		if hAuthTicket then
+			self.expected_ticket_handle = hAuthTicket
+			print("ticket", hAuthTicket)
 		else
 			print("error", err)
 		end

--- a/steam/src/steam.cpp
+++ b/steam/src/steam.cpp
@@ -170,6 +170,7 @@ static int Update(lua_State* L)
 		else if (id == GlobalAchievementPercentagesReady_t::k_iCallback) SteamListener_InvokeGeneric("GlobalAchievementPercentagesReady_t");
 		// user
 		else if (id == MicroTxnAuthorizationResponse_t::k_iCallback) SteamListener_Invoke(SteamUser_OnMicroTxnAuthorizationResponse, data);
+		else if (id == GetTicketForWebApiResponse_t::k_iCallback) SteamListener_Invoke(SteamUser_OnGetTicketForWebApiResponse, data);
 		else if (id == SteamServersConnected_t::k_iCallback) SteamListener_InvokeGeneric("SteamServersConnected_t");
 		else if (id == SteamServerConnectFailure_t::k_iCallback) SteamListener_InvokeGeneric("SteamServerConnectFailure_t");
 		else if (id == SteamServersDisconnected_t::k_iCallback) SteamListener_InvokeGeneric("SteamServersDisconnected_t");
@@ -389,6 +390,7 @@ static const luaL_reg Module_methods[] = {
 	{ "user_is_phone_requiring_verification", SteamUser_IsPhoneRequiringVerification },
 	{ "user_is_two_factor_enabled", SteamUser_IsTwoFactorEnabled },
 	{ "user_get_auth_session_ticket", SteamUser_GetAuthSessionTicket },
+	{ "user_get_auth_ticket_for_web_api", SteamUser_GetAuthTicketForWebAPI },
 
 	// MATCHMAKING
 	{ "matchmaking_request_lobby_list", SteamMatchmaking_RequestLobbyList },

--- a/steam/src/steam_user.h
+++ b/steam/src/steam_user.h
@@ -6,6 +6,7 @@
 #include <dmsdk/sdk.h>
 
 int SteamUser_OnMicroTxnAuthorizationResponse(lua_State* L, void* data);
+int SteamUser_OnGetTicketForWebApiResponse(lua_State* L, void* data);
 
 int SteamUser_Init(lua_State* L);
 int SteamUser_GetSteamId(lua_State* L);
@@ -18,6 +19,7 @@ int SteamUser_IsPhoneIdentifying(lua_State* L);
 int SteamUser_IsPhoneRequiringVerification(lua_State* L);
 int SteamUser_IsTwoFactorEnabled(lua_State* L);
 int SteamUser_GetAuthSessionTicket(lua_State* L);
+int SteamUser_GetAuthTicketForWebAPI(lua_State* L);
 
 #endif
 


### PR DESCRIPTION
Hey hey!

Our game needs to authenticate to our backend, and for Steam using the [ISteamUser::GetAuthTicketForWebApi](https://partner.steamgames.com/doc/api/ISteamUser#GetAuthTicketForWebApi) seems to be the logical choice.

This PR exposed this function to Lua and implements the accompanying callback.