### PR TITLE
add `steam.utils_is_steam_overlay_available`

### DIFF
--- a/steam/api/steam.script_api
+++ b/steam/api/steam.script_api
@@ -1689,6 +1689,13 @@
     - name: running_on_steamdeck
       type: boolean
 
+  - name: utils_is_steam_overlay_available
+    type: function
+    desc: Returns true if the Steam Overlay is running and the user can access it.
+    returns:
+    - name: steam_overlay_available
+      type: boolean
+
   - name: utils_get_image_size
     type: function
     desc: Get size of image. 

--- a/steam/src/steam.cpp
+++ b/steam/src/steam.cpp
@@ -323,6 +323,7 @@ static const luaL_reg Module_methods[] = {
 	{ "utils_get_app_id", SteamUtils_GetAppId },
 	{ "utils_get_seconds_since_app_active", SteamUtils_GetSecondsSinceAppActive },
 	{ "utils_is_steam_running_on_steam_deck", SteamUtils_IsSteamRunningOnSteamDeck },
+	{ "utils_is_steam_overlay_available", SteamUtils_IsSteamOverlayAvailable },
 	{ "utils_get_image_size", SteamUtils_GetImageSize },
 	{ "utils_get_image_rgba", SteamUtils_GetImageRGBA },
 	{ "utils_get_server_real_time", SteamUtils_GetServerRealTime },

--- a/steam/src/steam_utils.cpp
+++ b/steam/src/steam_utils.cpp
@@ -111,6 +111,19 @@ int SteamUtils_IsSteamRunningOnSteamDeck(lua_State* L)
 	return 1;
 }
 
+/** Returns true if the Steam Overlay is running and the user can access it.
+ * @name utils_is_steam_overlay_available
+ * @treturn boolean steam_overlay_available
+ */
+int SteamUtils_IsSteamOverlayAvailable(lua_State* L)
+{
+	if (!g_SteamUtils) return 0;
+	DM_LUA_STACK_CHECK(L, 1);
+
+	lua_pushboolean(L, g_SteamUtils->IsOverlayEnabled());
+	return 1;
+}
+
 
 /** Get size of image
  * @name utils_get_image_size

--- a/steam/src/steam_utils.h
+++ b/steam/src/steam_utils.h
@@ -12,6 +12,7 @@ int SteamUtils_Init(lua_State* L);
 int SteamUtils_GetAppId(lua_State* L);
 int SteamUtils_GetSecondsSinceAppActive(lua_State* L);
 int SteamUtils_IsSteamRunningOnSteamDeck(lua_State* L);
+int SteamUtils_IsSteamOverlayAvailable(lua_State* L);
 int SteamUtils_GetImageSize(lua_State* L);
 int SteamUtils_GetImageRGBA(lua_State* L);
 int SteamUtils_GetServerRealTime(lua_State* L);


### PR DESCRIPTION
Implements simple access function to [ISteamUtils::IsOverlayEnabled](https://partner.steamgames.com/doc/api/ISteamUtils#IsOverlayEnabled) which allows checking if the Steam Overlay is enabled/accessible for the current game session.

We require this to check before making an in-app purchase with Steam (via PlayFab) as if the overlay is not enabled, the purchase attempt will silently fail with no indication to user or feedback to the app code. (I have successfully tested that this function solves our problem in a local build)